### PR TITLE
Use an SSH key and an SSH URL for fetching repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Gemfile.lock
 .ruby-gemset
 *.gem
 /.idea
+.DS_Store

--- a/lib/testributor/client.rb
+++ b/lib/testributor/client.rb
@@ -6,8 +6,13 @@ module Testributor
   class Client
     attr_reader :token
     REQUEST_ERROR_TIMEOUT_SECONDS = 10
-    CONNECTION_ERRORS = [Faraday::ConnectionFailed, Net::ReadTimeout,
-                         OAuth2::Error, Faraday::TimeoutError]
+    CONNECTION_ERRORS = [
+      Faraday::ConnectionFailed,
+      Net::ReadTimeout,
+      OAuth2::Error,
+      Faraday::TimeoutError,
+      Testributor::InvalidSshKeyError
+    ]
 
     # Use this method only when the exception occurs in testributor's side.
     # In this way, there is no need to restart the gem, each time testributor
@@ -58,8 +63,8 @@ module Testributor
       end
     end
 
-    def get_current_project
-      request(:get, 'projects/current').parsed
+    def get_setup_data
+      request(:get, 'projects/setup_data').parsed
     end
 
     # Asks the testributor API for a batch of jobs to run

--- a/lib/testributor/test_job.rb
+++ b/lib/testributor/test_job.rb
@@ -1,9 +1,8 @@
 # This is a wrapper class around the test_job response from testributor
 module Testributor
   class TestJob
-    attr_reader :id, :commit_sha, :command, :repo, :api_client,
-      :sent_at_seconds_since_epoch, :queued_at_seconds_since_epoch,
-      :started_at_seconds_since_epoch
+    attr_reader :id, :commit_sha, :command, :sent_at_seconds_since_epoch,
+      :queued_at_seconds_since_epoch, :started_at_seconds_since_epoch
 
     def initialize(job_response)
       @id = job_response["id"]


### PR DESCRIPTION
Switched from the https method, which uses an OAuth2 access token,
to the SSH method, which uses an SSH key, for fetching the target
repo that contains the tests the worker needs to run.

We do this to increase our security exposure as the OAuth2 tokens
won't be transmitted to the workers anymore. Instead, an SSH key
(that has to be already in place) will be used. The SSH keys can
be set up to allow access to a single repo only, as opposed to the
tokens that are tied to the repo owner and will allow full access
to any repo allowed by the token's scopes.

https://trello.com/c/qYMdGU2h/175-don-t-send-github-api-key-to-workers
