### PR TITLE
Replace number-of-jobs-in-queue condition with workload calculation

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,23 @@
+# Use different redis settings for tests
+ENV['TESTRIBUTOR_REDIS_URL'] = ENV['TESTRIBUTOR_REDIS_TEST_URL'] || '127.0.0.1'
+ENV['TESTRIBUTOR_REDIS_PORT'] = ENV['TESTRIBUTOR_REDIS_TEST_PORT'] || '6379'
+ENV['TESTRIBUTOR_REDIS_DB'] = ENV['TESTRIBUTOR_REDIS_TEST_DB'] || 'testributor_test'
+
 require 'testributor'
 require 'minitest/autorun'
 require 'minitest/spec'
 require 'minitest/pride'
 require 'minitest/stub_any_instance'
 require "mocha/mini_test"
+require "timecop"
+require "minitest/stub_const"
+
+class MiniTest::Test
+
+  def setup
+    redis = Redis.new(host: Testributor::REDIS_HOST,
+                      port: Testributor::REDIS_PORT,
+                      db: Testributor::REDIS_DB)
+    redis.flushall
+  end
+end

--- a/test/testributor/manager_test.rb
+++ b/test/testributor/manager_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class ManagerTest < MiniTest::Test
+  describe "#workload_in_queue" do
+    subject { Testributor::Manager.new }
+    before do
+      subject.stubs(:log) # Skip output
+
+      subject.send(:redis).lpush(
+        Testributor::REDIS_JOBS_LIST,
+        { cost_prediction: 23, command: 'run something' }.to_json)
+      subject.send(:redis).lpush(
+        Testributor::REDIS_JOBS_LIST,
+        { cost_prediction: 12, command: 'run something else' }.to_json)
+    end
+
+    it "returns the total workload in queue" do
+      subject.send(:workload_in_queue).must_equal 35
+    end
+  end
+
+  describe "#low_workload?" do
+    subject { Testributor::Manager.new }
+
+    it "returns true when total workload (in queue and on worker) is below 10" do
+      subject.stubs(:workload_in_queue).returns(2)
+      Testributor.stubs(:workload_on_worker).returns(2)
+      subject.send(:low_workload?).must_equal true
+    end
+
+    it "returns false when total workload (in queue and on worker) is above 10" do
+      subject.stubs(:workload_in_queue).returns(2)
+      Testributor.stubs(:workload_on_worker).returns(10)
+      subject.send(:low_workload?).must_equal false
+    end
+
+    it "returns false when workload_in_queue is nil" do
+      subject.stubs(:workload_in_queue).returns(nil)
+      Testributor.stubs(:workload_on_worker).returns(10)
+      subject.send(:low_workload?).must_equal false
+    end
+
+    it "returns false when Testributor.workload_on_worker is nil" do
+      subject.stubs(:workload_in_queue).returns(20)
+      Testributor.stubs(:workload_on_worker).returns(nil)
+      subject.send(:low_workload?).must_equal false
+    end
+  end
+end

--- a/test/testributor/worker_test.rb
+++ b/test/testributor/worker_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class WorkerTest < MiniTest::Test
+  describe "#handle_next_job" do
+    subject { Testributor::Worker.new }
+
+    describe "when there is a job in the queue" do
+      before do
+        subject.stubs(:log) # Skip output
+      end
+
+      it "sets the worker_current_job_* variables on Testributor when there is a job" do
+        subject.send(:redis).lpush(
+          Testributor::REDIS_JOBS_LIST,
+          { cost_prediction: 23,
+            command: 'run something',
+            test_run: { id: 23 } }.to_json)
+        Testributor::TestJob.any_instance.stubs(:run).returns({})
+        Timecop.freeze do
+          subject.send(:handle_next_job)
+          Testributor.instance_variable_get(:@worker_current_job_started_at).
+            must_equal Time.now
+          Testributor.instance_variable_get(:@worker_current_job_cost_prediction).
+            must_equal 23
+        end
+      end
+
+      it "sets the worker_current_job_* variables on Testributor to nil when there is no job" do
+        # Don't sleep in tests
+        Testributor::Worker.stub_const(:NO_JOBS_IN_QUEUE_TIMEOUT_SECONDS, 0) do
+          Timecop.freeze do
+            subject.send(:handle_next_job)
+            Testributor.instance_variable_get(:@worker_current_job_started_at).
+              must_equal nil
+            Testributor.instance_variable_get(:@worker_current_job_cost_prediction).
+              must_equal nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/testributor.gemspec
+++ b/testributor.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.executables      << 'testributor'
 
   %w(oauth2 rugged minitest redis).each { |gem|  s.add_runtime_dependency gem  }
-  %w(pry pry-nav minitest-stub_any_instance).each { |gem| s.add_development_dependency gem }
+  %w(pry pry-nav minitest-stub_any_instance timecop minitest-stub-const).each { |gem| s.add_development_dependency gem }
 end


### PR DESCRIPTION
https://trello.com/c/T5NVbbO7/178-each-worker-should-be-assigned-a-batch-of-jobs-based-on-the-estimated-running-time

Related: https://github.com/ispyropoulos/katana/pull/107/files
