### PR TITLE
Expose variables and functions in build commands script

### DIFF
--- a/lib/testributor.rb
+++ b/lib/testributor.rb
@@ -197,6 +197,7 @@ end
 
 Testributor.allow_retries_on_failure = true
 
+require 'testributor/constants'
 require 'testributor/manager'
 require 'testributor/reporter'
 require 'testributor/worker'

--- a/lib/testributor/constants.rb
+++ b/lib/testributor/constants.rb
@@ -1,0 +1,25 @@
+module Testributor
+  BASH_FUNCTIONS = <<-FUNCTIONS
+  # Calls "git diff" between the specified commits and checks if the changed files
+  # include the string passed as an argument. If not both commits are set it means
+  # we should consider all files as changed so we return true (e.g. when setting
+  # up workers we don't have a previous commit)
+  function changed_file_paths_match {
+    if [[ -n "$CURRENT_COMMIT" && -n "$PREVIOUS_COMMIT" ]]
+    then
+      test -n "$(git diff --name-only $CURRENT_COMMIT $PREVIOUS_COMMIT | grep $1)"
+    else
+      true
+    fi
+  }
+
+  function commit_changed {
+    if [[ -n "$CURRENT_COMMIT" && -n "$PREVIOUS_COMMIT" ]]
+    then
+      $CURRENT_COMMIT != $PREVIOUS_COMMIT
+    else
+      true
+    fi
+  }
+  FUNCTIONS
+end


### PR DESCRIPTION
Now the user can use these variables and functions as conditions for the
various commands.

E.g.
  bundle install should only be run when Gemfile.lock is changed. This
  can be achieved as following:

  if changed_file_paths_match "Gemfile.lock"
  then
    bundle install
  fi

E.g.2
  The user might want to install special packages only on setup. This
  can be achieved as following:

  if [[ -n $WORKER_INITIALIZING ]]
  then
    apt-get update
    apt-get install -y phantomjs
  fi
