### PR TITLE
Flush the Redis database when starting

### DIFF
--- a/lib/testributor.rb
+++ b/lib/testributor.rb
@@ -104,6 +104,11 @@ module Testributor
     @redis = Redis.new(:host => REDIS_HOST, :port => REDIS_PORT, :db => REDIS_DB)
     @uuid = SecureRandom.uuid
 
+    # Clear any relics. Stopped workers should start fresh to avoid sending
+    # irrelevant statistics about queue times etc. Katana reassigns jobs when
+    # workers die so it should be no problem.
+    @redis.flushdb
+
     @current_project = Project.new(client.get_current_project)
 
     log "Starting Worker thread"


### PR DESCRIPTION
to avoid sending irrelevant times about how long each job was in queue
etc. Katana reassigns jobs to other workers so it should be no problem
except for the case described here:

https://trello.com/c/mvcmcNCZ/218-make-workers-use-the-same-uuid-every-time-they-are-started

The card has a proposed solution for when we get there.
